### PR TITLE
Document archive status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Foundational libraries and helper binaries for cross-language support, written i
 >
 > You can find the new repositories below:
 > - If it was a binary, it'll be in a new repository named after the binary.
->   - `tracer`: planned to be folded into `https://github.com/fossas/diagnose`.
+>   - `tracer`: planned to be folded into https://github.com/fossas/diagnose.
 > - If it was a library, it'll be in a new repository named after the library, usually prepended with `lib-` or suffixed by the language (`-rs`).
 >   The intention is that if the library is meant to be canonical (so it's used across languages, via FFI) it gets the `lib-` prefix.
 >   If it's language specific, it gets the `-rs` suffix.
->   - `srclib`: `https://github.com/fossas/srclib-rs`
->   - `traceconf`: `https://github.com/fossas/traceconf-rs`
->   - `snippets`: `https://github.com/fossas/lib-snippets`
->   - `archive`: `https://github.com/fossas/lib-archive`
->   - `berkeleydb`: `https://github.com/fossas/lib-berkeleydb`
+>   - `srclib`: https://github.com/fossas/srclib-rs
+>   - `traceconf`: https://github.com/fossas/traceconf-rs
+>   - `snippets`: https://github.com/fossas/lib-snippets
+>   - `archive`: https://github.com/fossas/lib-archive
+>   - `berkeleydb`: https://github.com/fossas/lib-berkeleydb
 >   - `fingerprint`: Folding into `vsi`.
->   - `vsi`: planned to be exposed as a library only at `https://github.com/fossas/lib-vsi`.
+>   - `vsi`: planned to be exposed as a library only at https://github.com/fossas/lib-vsi.
 
 ## finding your way around
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,31 @@
-<div align="center">
-
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffoundation-libs.svg?type=small)](https://app.fossa.com/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffoundation-libs?ref=badge_small)
-
-</div>
-
 # foundation-libs
 
 Foundational libraries and helper binaries for cross-language support, written in Rust.
 <sup>_[(TOC?)](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/)_</sup>
 
-Include directly in Rust projects.
-For other languages, interact with FFI or executing binaries directly.
-
-(Walkthroughs to come)
+> [!IMPORTANT]
+> This repository is archived, but most packages within it are still considered actively maintained.
+>
+> As we make changes to these packages we'll extract them into their own repositories
+> (and shared libraries into their own repositories).
+>
+> This extraction is planned to be performed lazily (in the programming sense),
+> meaning that we'll extract the package the first time we need to make changes.
+> If a repository below doesn't yet exist, or is empty, this repository is the canonical latest version.
+>
+> You can find the new repositories below:
+> - If it was a binary, it'll be in a new repository named after the binary.
+>   - `tracer`: planned to be folded into `https://github.com/fossas/diagnose`.
+> - If it was a library, it'll be in a new repository named after the library, usually prepended with `lib-` or suffixed by the language (`-rs`).
+>   The intention is that if the library is meant to be canonical (so it's used across languages, via FFI) it gets the `lib-` prefix.
+>   If it's language specific, it gets the `-rs` suffix.
+>   - `srclib`: `https://github.com/fossas/srclib-rs`
+>   - `traceconf`: `https://github.com/fossas/traceconf-rs`
+>   - `snippets`: `https://github.com/fossas/lib-snippets`
+>   - `archive`: `https://github.com/fossas/lib-archive`
+>   - `berkeleydb`: `https://github.com/fossas/lib-berkeleydb`
+>   - `fingerprint`: Folding into `vsi`.
+>   - `vsi`: planned to be exposed as a library only at `https://github.com/fossas/lib-vsi`.
 
 ## finding your way around
 

--- a/snippets/src/language/cpp_98.rs
+++ b/snippets/src/language/cpp_98.rs
@@ -47,7 +47,6 @@ use crate::text::normalize_space;
 use crate::tree_sitter_consts::{NODE_KIND_FUNC_DEF, NODE_KIND_OPEN_BRACE};
 use crate::{impl_language, impl_prelude::*};
 
-use super::c99_tc3;
 use super::normalize_code::normalize_code;
 use super::normalize_comments::normalize_comments;
 use super::snippet_context::SnippetContext;

--- a/snippets/src/lib.rs
+++ b/snippets/src/lib.rs
@@ -404,7 +404,7 @@ pub enum Strategy {
 
 /// An extracted snippet from the given unit of source code.
 #[derive(Clone, Getters, CopyGetters, Index, Deref, Derivative, TypedBuilder)]
-#[derivative(PartialOrd, Ord, PartialEq, Eq)]
+#[derivative(Ord, PartialEq, Eq)]
 pub struct Snippet<L> {
     /// Metadata for the extracted snippet.
     #[getset(get_copy = "pub")]
@@ -428,6 +428,12 @@ pub struct Snippet<L> {
     /// but `PhantomData<T>` is always equal to itself for both checks.
     #[builder(default, setter(skip))]
     language: PhantomData<L>,
+}
+
+impl<L> PartialOrd for Snippet<L> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl<L> Snippet<L> {


### PR DESCRIPTION
As of today, Analysis decided to archive our monorepos in favor of lazily extracting packages into their own repositories.

This PR adds that to the readme; after this merges I'll set the repository to archived.

Rendered: https://github.com/fossas/foundation-libs/tree/archive#readme